### PR TITLE
feat(#3): automate nginx status check scripts

### DIFF
--- a/scripts/sprint2/check_nginx_health_endpoint.sh
+++ b/scripts/sprint2/check_nginx_health_endpoint.sh
@@ -27,9 +27,10 @@ RESET="\033[0m"
 info()    { echo -e "${GREEN}[INFO]${RESET} $*"; }
 error()   { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
 verbose() {
-  [[ "$VERBOSE" == true ]] && while IFS= read -r line; do
+  [[ "$VERBOSE" != true ]] && return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
     echo -e "${BLUE}[VERBOSE]${RESET} $line"
-  done
+  done < <([[ -t 0 ]] && echo "$*")
 }
 
 yell() { error "$0: $*" >&2; }

--- a/scripts/sprint2/check_nginx_health_endpoint.sh
+++ b/scripts/sprint2/check_nginx_health_endpoint.sh
@@ -28,9 +28,13 @@ info()    { echo -e "${GREEN}[INFO]${RESET} $*"; }
 error()   { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
 verbose() {
   [[ "$VERBOSE" != true ]] && return 0
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    echo -e "${BLUE}[VERBOSE]${RESET} $line"
-  done < <([[ -t 0 ]] && echo "$*")
+  if [[ -p /dev/stdin ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      echo -e "${BLUE}[VERBOSE]${RESET} $line"
+    done
+  elif [[ -n "$*" ]]; then
+    echo -e "${BLUE}[VERBOSE]${RESET} $*"
+  fi
 }
 
 yell() { error "$0: $*" >&2; }

--- a/scripts/sprint2/check_nginx_system_status.sh
+++ b/scripts/sprint2/check_nginx_system_status.sh
@@ -25,9 +25,13 @@ info()    { echo -e "${GREEN}[INFO]${RESET} $*"; }
 error()   { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
 verbose() {
   [[ "$VERBOSE" != true ]] && return 0
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    echo -e "${BLUE}[VERBOSE]${RESET} $line"
-  done < <([[ -t 0 ]] && echo "$*")
+  if [[ -p /dev/stdin ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      echo -e "${BLUE}[VERBOSE]${RESET} $line"
+    done
+  elif [[ -n "$*" ]]; then
+    echo -e "${BLUE}[VERBOSE]${RESET} $*"
+  fi
 }
 
 yell() { error "$0: $*" >&2; }

--- a/scripts/sprint2/check_nginx_system_status.sh
+++ b/scripts/sprint2/check_nginx_system_status.sh
@@ -24,9 +24,10 @@ RESET="\033[0m"
 info()    { echo -e "${GREEN}[INFO]${RESET} $*"; }
 error()   { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
 verbose() {
-  [[ "$VERBOSE" == true ]] && while IFS= read -r line; do
+  [[ "$VERBOSE" != true ]] && return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
     echo -e "${BLUE}[VERBOSE]${RESET} $line"
-  done
+  done < <([[ -t 0 ]] && echo "$*")
 }
 
 yell() { error "$0: $*" >&2; }

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -95,27 +95,27 @@ ensure_command_available() {
 }
 
 setup_cron_job() {
-  local cron_job="$CRON_JOB_SCHEDULE sudo $LOCAL_SCRIPT_PATH --address $ADDRESS >> $CRON_LOG_FILE 2>&1"
+  local cron_job="$CRON_JOB_SCHEDULE sudo $LOCAL_SCRIPT_PATH -v $ADDRESS >> $CRON_LOG_FILE 2>&1"
 
   info "Ensuring cron log directory: $CRON_LOG_DIR"
-  sudo mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
+  mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
 
   [[ -f "$CRON_LOG_FILE" ]] && {
     info "Removing old log file: $CRON_LOG_FILE"
-    sudo rm -f "$CRON_LOG_FILE" || die "Failed to remove old log file: $CRON_LOG_FILE"
+    rm -f "$CRON_LOG_FILE" || die "Failed to remove old log file: $CRON_LOG_FILE"
   }
 
-  sudo touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
-  sudo chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
+  touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
+  chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
 
   info "Updating cron jobs..."
   {
     crontab -l 2>/dev/null | grep -v "$LOCAL_SCRIPT_PATH"
     echo "$cron_job"
-  } | sudo crontab - || die "Failed to update cron jobs."
+  } | crontab - || die "Failed to update cron jobs."
 
   info "Cron job successfully added:"
-  sudo crontab -l | grep "$LOCAL_SCRIPT_PATH"
+  crontab -l | grep "$LOCAL_SCRIPT_PATH"
 }
 
 download_script() {

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -12,7 +12,7 @@ usage() {
     cat <<EOF
 Usage: $0 [OPTIONS]
 
-Schedules the Nginx health check script to run every 5 minutes via cron.
+Schedules the Nginx health check script to run every 5 minutes.
 
 Options:
   --address <ADDRESS>   Base URL to check (default: http://127.0.0.1)
@@ -24,76 +24,130 @@ EOF
 info()    { echo -e "\033[0;32m[INFO]\033[0m $*"; }
 error()   { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
 die()     { error "$*"; exit 1; }
+try()     { "$@" || die "Command failed: $*"; }
 
 ensure_sudo() { sudo -n true 2>/dev/null || die "Script requires sudo privileges."; }
 
-download_script() {
-    if [[ ! -f "$LOCAL_SCRIPT_PATH" ]]; then
-        info "Downloading monitoring script to $LOCAL_SCRIPT_PATH..."
-        curl -fsSL "$REPO_URL" -o "$LOCAL_SCRIPT_PATH" || die "Failed to download the script from $REPO_URL."
-    else
-        info "Script already exists at $LOCAL_SCRIPT_PATH. Skipping download."
-    fi
-
-    chmod +x "$LOCAL_SCRIPT_PATH" || die "Failed to make the script executable."
+detect_package_manager() {
+  for pm in apt dnf; do
+    command -v "$pm" &>/dev/null || continue
+    echo "$pm"
+    return 0
+  done
+  return 1
 }
 
-validate_script_dependencies() {
-    info "Validating dependencies for $LOCAL_SCRIPT_PATH..."
-    for cmd in jq curl; do
-        command -v "$cmd" &>/dev/null || die "Dependency '$cmd' is missing. Please install it."
-    done
-    info "All dependencies are available."
+map_package_name() {
+  local cmd="$1" pm="$2"
+
+  case "$pm" in
+    apt)
+      case "$cmd" in
+        jq) echo "jq" ;;
+        curl) echo "curl" ;;
+        crontab) echo "cron" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    dnf)
+      case "$cmd" in
+        jq) echo "jq" ;;
+        curl) echo "curl" ;;
+        crontab) echo "cronie" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+  return 0
+}
+
+install_package() {
+  local pkg="$1" pm="$2"
+
+  info "Using $pm to install '$pkg'"
+  case "$pm" in
+    apt)
+      try sudo apt-get update -y
+      try sudo apt-get install -y "$pkg"
+      ;;
+    dnf)
+      try sudo dnf install -y "$pkg"
+      ;;
+    *) die "Unsupported package manager: $pm" ;;
+  esac
+  return 0
+}
+
+ensure_command_available() {
+  local cmd="$1"
+
+  command -v "$cmd" &>/dev/null && return 0
+
+  local pm
+  pm=$(detect_package_manager) || die "No supported package manager found."
+
+  local pkg
+  pkg=$(map_package_name "$cmd" "$pm") || die "Could not map package for command: $cmd"
+
+  info "'$cmd' is not installed. Installing '$pkg'..."
+  install_package "$pkg" "$pm" || die "Failed to install package: $pkg"
+
+  command -v "$cmd" &>/dev/null || die "'$cmd' is still not available after installation."
+}
+
+download_script() {
+  if [[ ! -f "$LOCAL_SCRIPT_PATH" ]]; then
+    info "Downloading monitoring script to $LOCAL_SCRIPT_PATH..."
+    curl -fsSL "$REPO_URL" -o "$LOCAL_SCRIPT_PATH" || die "Failed to download the script from $REPO_URL."
+  else
+    info "Script already exists at $LOCAL_SCRIPT_PATH. Skipping download."
+  fi
+
+  chmod +x "$LOCAL_SCRIPT_PATH" || die "Failed to make the script executable."
 }
 
 setup_cron_job() {
-    local cron_job="$CRON_JOB_SCHEDULE $LOCAL_SCRIPT_PATH --address $ADDRESS >> $CRON_LOG_FILE 2>&1"
+  local cron_job="$CRON_JOB_SCHEDULE $LOCAL_SCRIPT_PATH --address $ADDRESS >> $CRON_LOG_FILE 2>&1"
 
-    info "Ensuring cron log directory: $CRON_LOG_DIR"
-    mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
-    touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
-    chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
+  info "Ensuring cron log directory: $CRON_LOG_DIR"
+  mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
+  touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
+  chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
 
-    info "Setting up cron job..."
-    (crontab -l 2>/dev/null | grep -v "$LOCAL_SCRIPT_PATH"; echo "$cron_job") | crontab - || die "Failed to add the cron job."
+  info "Setting up cron job..."
+  (crontab -l 2>/dev/null | grep -v "$LOCAL_SCRIPT_PATH"; echo "$cron_job") | crontab - || die "Failed to add the cron job."
 
-    info "Cron job successfully added:"
-    crontab -l | grep "$LOCAL_SCRIPT_PATH"
-}
-
-verify_cron_job() {
-    info "Verifying cron job..."
-    if crontab -l | grep -q "$LOCAL_SCRIPT_PATH"; then
-        info "Cron job is registered successfully."
-    else
-        die "Cron job registration failed."
-    fi
+  info "Cron job successfully added:"
+  crontab -l | grep "$LOCAL_SCRIPT_PATH"
 }
 
 main() {
-    ensure_sudo
+  ensure_sudo
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --address) {
-              shift
-              [[ $# -gt 0 ]] || die "Missing value for --address"
-              ADDRESS="$1"
-            } ;;
-            -h|--help) usage ;;
-            *) die "Unknown argument: $1" ;;
-        esac
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --address)
         shift
-    done
+        [[ $# -gt 0 ]] || die "Missing value for --address"
+        ADDRESS="$1"
+        ;;
+      -h|--help) usage ;;
+      *) die "Unknown argument: $1" ;;
+    esac
+    shift
+  done
 
-    info "Using address: $ADDRESS"
+  info "Using address: $ADDRESS"
 
-    download_script
-    validate_script_dependencies
-    setup_cron_job
-    verify_cron_job
+  for cmd in jq curl crontab; do
+    ensure_command_available "$cmd"
+  done
 
-    info "Nginx health endpoint monitoring setup completed."
+  download_script
+  setup_cron_job
+
+  info "Nginx health endpoint monitoring setup completed."
 }
 
 main "$@"

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -21,10 +21,10 @@ EOF
     exit 1
 }
 
-info()    { echo -e "\033[0;32m[INFO]\033[0m $*"; }
-error()   { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
-die()     { error "$*"; exit 1; }
-try()     { "$@" || die "Command failed: $*"; }
+info() { echo -e "\033[0;32m[INFO]\033[0m $*"; }
+error() { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
+die() { error "$*"; exit 1; }
+try() { "$@" || die "Command failed: $*"; }
 
 ensure_sudo() { sudo -n true 2>/dev/null || die "Script requires sudo privileges."; }
 
@@ -67,13 +67,11 @@ install_package() {
 
   info "Using $pm to install '$pkg'"
   case "$pm" in
-    apt)
+    apt) {
       try sudo apt-get update -y
       try sudo apt-get install -y "$pkg"
-      ;;
-    dnf)
-      try sudo dnf install -y "$pkg"
-      ;;
+    } ;;
+    dnf) try sudo dnf install -y "$pkg" ;;
     *) die "Unsupported package manager: $pm" ;;
   esac
   return 0

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/3-automate-nginx-status-check-scripts/scripts/sprint2/check_nginx_health_endpoint.sh"
+LOCAL_SCRIPT_PATH="/usr/local/bin/check_nginx_health_endpoint.sh"
+CRON_LOG_DIR="/var/log/nginx_health_cron"
+CRON_LOG_FILE="$CRON_LOG_DIR/health_check.log"
+CRON_JOB_SCHEDULE="*/5 * * * *"
+ADDRESS="http://127.0.0.1"
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Schedules the Nginx health check script to run every 5 minutes via cron.
+
+Options:
+  --address <ADDRESS>   Base URL to check (default: http://127.0.0.1)
+  -h, --help            Show this help message
+EOF
+    exit 1
+}
+
+info()    { echo -e "\033[0;32m[INFO]\033[0m $*"; }
+error()   { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
+die()     { error "$*"; exit 1; }
+
+ensure_sudo() { sudo -n true 2>/dev/null || die "Script requires sudo privileges."; }
+
+download_script() {
+    if [[ ! -f "$LOCAL_SCRIPT_PATH" ]]; then
+        info "Downloading monitoring script to $LOCAL_SCRIPT_PATH..."
+        curl -fsSL "$REPO_URL" -o "$LOCAL_SCRIPT_PATH" || die "Failed to download the script from $REPO_URL."
+    else
+        info "Script already exists at $LOCAL_SCRIPT_PATH. Skipping download."
+    fi
+
+    chmod +x "$LOCAL_SCRIPT_PATH" || die "Failed to make the script executable."
+}
+
+validate_script_dependencies() {
+    info "Validating dependencies for $LOCAL_SCRIPT_PATH..."
+    for cmd in jq curl; do
+        command -v "$cmd" &>/dev/null || die "Dependency '$cmd' is missing. Please install it."
+    done
+    info "All dependencies are available."
+}
+
+setup_cron_job() {
+    local cron_job="$CRON_JOB_SCHEDULE $LOCAL_SCRIPT_PATH --address $ADDRESS >> $CRON_LOG_FILE 2>&1"
+
+    info "Ensuring cron log directory: $CRON_LOG_DIR"
+    mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
+    touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
+    chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
+
+    info "Setting up cron job..."
+    (crontab -l 2>/dev/null | grep -v "$LOCAL_SCRIPT_PATH"; echo "$cron_job") | crontab - || die "Failed to add the cron job."
+
+    info "Cron job successfully added:"
+    crontab -l | grep "$LOCAL_SCRIPT_PATH"
+}
+
+verify_cron_job() {
+    info "Verifying cron job..."
+    if crontab -l | grep -q "$LOCAL_SCRIPT_PATH"; then
+        info "Cron job is registered successfully."
+    else
+        die "Cron job registration failed."
+    fi
+}
+
+main() {
+    ensure_sudo
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --address) {
+              shift
+              [[ $# -gt 0 ]] || die "Missing value for --address"
+              ADDRESS="$1"
+            } ;;
+            -h|--help) usage ;;
+            *) die "Unknown argument: $1" ;;
+        esac
+        shift
+    done
+
+    info "Using address: $ADDRESS"
+
+    download_script
+    validate_script_dependencies
+    setup_cron_job
+    verify_cron_job
+
+    info "Nginx health endpoint monitoring setup completed."
+}
+
+main "$@"

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -115,21 +115,23 @@ ensure_command_available() {
 }
 
 setup_cron_job() {
-  local cron_job="$CRON_JOB_SCHEDULE sudo $LOCAL_SCRIPT_PATH -v $ADDRESS >> $CRON_LOG_FILE 2>&1" user="${TARGET_USER:-ec2-user}"
+  local cron_job="$CRON_JOB_SCHEDULE sudo $LOCAL_SCRIPT_PATH -v $ADDRESS >> $CRON_LOG_FILE 2>&1"
+  local user="${TARGET_USER:-ec2-user}"  # Use TARGET_USER or fallback to current user
 
   info "Ensuring cron log directory: $CRON_LOG_DIR"
   mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
-
-  touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
-  chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
-
-  info "Setting ownership of log directory to $user"
-  chown -R "$user:$user" "$CRON_LOG_DIR" || die "Failed to set ownership of $CRON_LOG_DIR to $user."
 
   [[ -f "$CRON_LOG_FILE" ]] && {
     info "Removing old log file: $CRON_LOG_FILE"
     rm -f "$CRON_LOG_FILE" || die "Failed to remove old log file: $CRON_LOG_FILE"
   }
+
+  touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
+  chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
+  chown "$user:$user" "$CRON_LOG_FILE" || die "Failed to set ownership of $CRON_LOG_FILE to $user."
+
+  info "Setting ownership of log directory to $user"
+  chown -R "$user:$user" "$CRON_LOG_DIR" || die "Failed to set ownership of $CRON_LOG_DIR to $user."
 
   info "Updating cron jobs..."
   {

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -120,6 +120,9 @@ setup_cron_job() {
   info "Ensuring cron log directory: $CRON_LOG_DIR"
   mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
 
+  touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
+  chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
+
   info "Setting ownership of log directory to $user"
   chown -R "$user:$user" "$CRON_LOG_DIR" || die "Failed to set ownership of $CRON_LOG_DIR to $user."
 
@@ -127,9 +130,6 @@ setup_cron_job() {
     info "Removing old log file: $CRON_LOG_FILE"
     rm -f "$CRON_LOG_FILE" || die "Failed to remove old log file: $CRON_LOG_FILE"
   }
-
-  touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
-  chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
 
   info "Updating cron jobs..."
   {

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -98,18 +98,24 @@ setup_cron_job() {
   local cron_job="$CRON_JOB_SCHEDULE sudo $LOCAL_SCRIPT_PATH --address $ADDRESS >> $CRON_LOG_FILE 2>&1"
 
   info "Ensuring cron log directory: $CRON_LOG_DIR"
-  mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
-  touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
-  chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
+  sudo mkdir -p "$CRON_LOG_DIR" || die "Failed to create log directory: $CRON_LOG_DIR"
+
+  [[ -f "$CRON_LOG_FILE" ]] && {
+    info "Removing old log file: $CRON_LOG_FILE"
+    sudo rm -f "$CRON_LOG_FILE" || die "Failed to remove old log file: $CRON_LOG_FILE"
+  }
+
+  sudo touch "$CRON_LOG_FILE" || die "Failed to create log file: $CRON_LOG_FILE"
+  sudo chmod 644 "$CRON_LOG_FILE" || die "Failed to set permissions on log file: $CRON_LOG_FILE"
 
   info "Updating cron jobs..."
   {
     crontab -l 2>/dev/null | grep -v "$LOCAL_SCRIPT_PATH"
     echo "$cron_job"
-  } | crontab - || die "Failed to update cron jobs."
+  } | sudo crontab - || die "Failed to update cron jobs."
 
   info "Cron job successfully added:"
-  crontab -l | grep "$LOCAL_SCRIPT_PATH"
+  sudo crontab -l | grep "$LOCAL_SCRIPT_PATH"
 }
 
 download_script() {

--- a/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
+++ b/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/3-automate-nginx-status-check-scripts/scripts/sprint2/check_nginx_health_endpoint.sh"
+REPO_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/main/scripts/sprint2/check_nginx_health_endpoint.sh"
 LOCAL_SCRIPT_PATH="/usr/local/bin/check_nginx_health_endpoint.sh"
 CRON_LOG_DIR="/var/log/nginx_health_cron"
 CRON_LOG_FILE="$CRON_LOG_DIR/health_check.log"

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -91,6 +91,7 @@ reload_systemd() {
 enable_and_start_timer() {
   info "Enabling and starting the timer: $SERVICE_NAME.timer"
   systemctl enable --now "${SERVICE_NAME}.timer"
+  systemctl restart "${SERVICE_NAME}.service"
 }
 
 verify_timer() {

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="nginx_status_check"
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+TIMER_FILE="/etc/systemd/system/${SERVICE_NAME}.timer"
+SCRIPT_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/main/scripts/sprint2/check_nginx_system_status.sh"
+SCRIPT_PATH="/usr/local/bin/check_nginx_system_status.sh"
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Automates scheduling of the Nginx system status check using systemd timer.
+
+Options:
+  -h, --help     Show this help message
+EOF
+  exit 1
+}
+
+info() { echo -e "\033[0;32m[INFO]\033[0m $*"; }
+error() { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
+die() { error "$1"; exit "${2:-1}"; }
+
+ensure_sudo() { sudo -n true 2>/dev/null || die "This script requires sudo privileges."; }
+
+download_script() {
+  info "Downloading the Nginx status check script to $SCRIPT_PATH"
+  sudo curl -fsSL "$SCRIPT_URL" -o "$SCRIPT_PATH"
+  sudo chmod +x "$SCRIPT_PATH"
+  [[ -x "$SCRIPT_PATH" ]] || die "Failed to download or set up the script at $SCRIPT_PATH"
+}
+
+create_service_file() {
+  info "Creating systemd service file: $SERVICE_FILE"
+  sudo tee "$SERVICE_FILE" > /dev/null <<EOF
+[Unit]
+Description=Check Nginx System Status
+After=network.target
+
+[Service]
+ExecStart=$SCRIPT_PATH
+StandardOutput=journal
+StandardError=journal
+EOF
+  sudo chmod 644 "$SERVICE_FILE"
+}
+
+create_timer_file() {
+  info "Creating systemd timer file: $TIMER_FILE"
+  sudo tee "$TIMER_FILE" > /dev/null <<EOF
+[Unit]
+Description=Timer to run ${SERVICE_NAME}.service every 5 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+  sudo chmod 644 "$TIMER_FILE"
+}
+
+reload_systemd() {
+  info "Reloading systemd daemon"
+  sudo systemctl daemon-reload
+}
+
+enable_and_start_timer() {
+  info "Enabling and starting the timer: $SERVICE_NAME.timer"
+  sudo systemctl enable --now "${SERVICE_NAME}.timer"
+}
+
+verify_timer() {
+  info "Verifying the systemd timer setup"
+  systemctl list-timers | grep -i "$SERVICE_NAME" || die "Timer setup verification failed."
+}
+
+main() {
+  ensure_sudo
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage ;;
+      *) die "Unknown option: $1" ;;
+    esac
+  done
+
+  download_script
+  create_service_file
+  create_timer_file
+  reload_systemd
+  enable_and_start_timer
+  verify_timer
+
+  info "Systemd timer for Nginx status check has been successfully set up!"
+}
+
+main "$@"

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -95,7 +95,10 @@ enable_and_start_timer() {
 
 verify_timer() {
   info "Verifying the systemd timer setup"
-  systemctl list-timers | grep -i "$SERVICE_NAME" || die "Timer setup verification failed."
+  systemctl list-timers --all | grep -i "$SERVICE_NAME" || die "Timer setup verification failed."
+
+  info "Timer verified successfully:"
+  systemctl list-timers --all | grep -i "$SERVICE_NAME"
 }
 
 main() {

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -91,6 +91,7 @@ reload_systemd() {
 enable_and_start_timer() {
   info "Enabling and starting the timer: $SERVICE_NAME.timer"
   systemctl enable --now "${SERVICE_NAME}.timer"
+  sleep 2
   systemctl restart "${SERVICE_NAME}.service"
 }
 

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -58,7 +58,7 @@ Description=Check Nginx System Status
 After=network.target
 
 [Service]
-ExecStart=sudo $SCRIPT_PATH
+ExecStart=$SCRIPT_PATH
 StandardOutput=journal
 StandardError=journal
 User=root

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -23,28 +23,36 @@ info() { echo -e "\033[0;32m[INFO]\033[0m $*"; }
 error() { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
 die() { error "$1"; exit "${2:-1}"; }
 
-ensure_sudo() { sudo -n true 2>/dev/null || die "This script requires sudo privileges."; }
+ensure_sudo() { sudo -n true 2>/dev/null || die "This script requires privileges."; }
 
 cleanup_previous_setup() {
   info "Cleaning up previous timer and service..."
-  sudo systemctl stop "${SERVICE_NAME}.timer" || true
-  sudo systemctl stop "${SERVICE_NAME}.service" || true
-  sudo systemctl disable "${SERVICE_NAME}.timer" || true
-  sudo systemctl disable "${SERVICE_NAME}.service" || true
-  sudo rm -f "$TIMER_FILE" "$SERVICE_FILE" || true
-  sudo systemctl daemon-reload
+  systemctl list-units --type=timer --all | grep -q "${SERVICE_NAME}.timer" &&
+    systemctl stop "${SERVICE_NAME}.timer" &&
+    systemctl disable "${SERVICE_NAME}.timer" ||
+    info "Timer not found or already stopped."
+
+  systemctl list-units --type=service --all | grep -q "${SERVICE_NAME}.service" &&
+    systemctl stop "${SERVICE_NAME}.service" &&
+    systemctl disable "${SERVICE_NAME}.service" ||
+    info "Service not found or already stopped."
+
+  rm -f "$TIMER_FILE" "$SERVICE_FILE" || true
+
+  systemctl daemon-reload
 }
+
 
 download_script() {
   info "Downloading the Nginx status check script to $SCRIPT_PATH"
-  sudo curl -fsSL "$SCRIPT_URL" -o "$SCRIPT_PATH"
-  sudo chmod +x "$SCRIPT_PATH"
+  curl -fsSL "$SCRIPT_URL" -o "$SCRIPT_PATH"
+  chmod +x "$SCRIPT_PATH"
   [[ -x "$SCRIPT_PATH" ]] || die "Failed to download or set up the script at $SCRIPT_PATH"
 }
 
 create_service_file() {
   info "Creating systemd service file: $SERVICE_FILE"
-  sudo tee "$SERVICE_FILE" > /dev/null <<EOF
+  tee "$SERVICE_FILE" > /dev/null <<EOF
 [Unit]
 Description=Check Nginx System Status
 After=network.target
@@ -55,12 +63,12 @@ StandardOutput=journal
 StandardError=journal
 User=root
 EOF
-  sudo chmod 644 "$SERVICE_FILE"
+  chmod 644 "$SERVICE_FILE"
 }
 
 create_timer_file() {
   info "Creating systemd timer file: $TIMER_FILE"
-  sudo tee "$TIMER_FILE" > /dev/null <<EOF
+  tee "$TIMER_FILE" > /dev/null <<EOF
 [Unit]
 Description=Timer to run ${SERVICE_NAME}.service every 5 minutes
 
@@ -72,17 +80,17 @@ Persistent=true
 [Install]
 WantedBy=timers.target
 EOF
-  sudo chmod 644 "$TIMER_FILE"
+  chmod 644 "$TIMER_FILE"
 }
 
 reload_systemd() {
   info "Reloading systemd daemon"
-  sudo systemctl daemon-reload
+  systemctl daemon-reload
 }
 
 enable_and_start_timer() {
   info "Enabling and starting the timer: $SERVICE_NAME.timer"
-  sudo systemctl enable --now "${SERVICE_NAME}.timer"
+  systemctl enable --now "${SERVICE_NAME}.timer"
 }
 
 verify_timer() {

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -6,9 +6,6 @@ SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 TIMER_FILE="/etc/systemd/system/${SERVICE_NAME}.timer"
 SCRIPT_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/main/scripts/sprint2/check_nginx_system_status.sh"
 SCRIPT_PATH="/usr/local/bin/check_nginx_system_status.sh"
-LOG_DIR="/var/log/nginx_status"
-ONLINE_LOG="$LOG_DIR/online.log"
-OFFLINE_LOG="$LOG_DIR/offline.log"
 
 usage() {
   cat <<EOF
@@ -43,14 +40,6 @@ download_script() {
   sudo curl -fsSL "$SCRIPT_URL" -o "$SCRIPT_PATH"
   sudo chmod +x "$SCRIPT_PATH"
   [[ -x "$SCRIPT_PATH" ]] || die "Failed to download or set up the script at $SCRIPT_PATH"
-}
-
-create_log_directory() {
-  info "Setting up log directory: $LOG_DIR"
-  sudo mkdir -p "$LOG_DIR"
-  sudo touch "$ONLINE_LOG" "$OFFLINE_LOG"
-  sudo chmod 644 "$ONLINE_LOG" "$OFFLINE_LOG"
-  sudo chown -R root:root "$LOG_DIR"
 }
 
 create_service_file() {
@@ -113,7 +102,6 @@ main() {
 
   cleanup_previous_setup
   download_script
-  create_log_directory
   create_service_file
   create_timer_file
   reload_systemd

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SERVICE_NAME="nginx_status_check"
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 TIMER_FILE="/etc/systemd/system/${SERVICE_NAME}.timer"
-SCRIPT_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/main/scripts/sprint2/check_nginx_system_status.sh"
+SCRIPT_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/3-automate-nginx-status-check-scripts/scripts/sprint2/check_nginx_system_status.sh"
 SCRIPT_PATH="/usr/local/bin/check_nginx_system_status.sh"
 
 usage() {

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -58,7 +58,7 @@ Description=Check Nginx System Status
 After=network.target
 
 [Service]
-ExecStart=$SCRIPT_PATH
+ExecStart=sudo $SCRIPT_PATH
 StandardOutput=journal
 StandardError=journal
 User=root

--- a/scripts/sprint2/schedule_nginx_systemd_timer.sh
+++ b/scripts/sprint2/schedule_nginx_systemd_timer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SERVICE_NAME="nginx_status_check"
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 TIMER_FILE="/etc/systemd/system/${SERVICE_NAME}.timer"
-SCRIPT_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/3-automate-nginx-status-check-scripts/scripts/sprint2/check_nginx_system_status.sh"
+SCRIPT_URL="https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/main/scripts/sprint2/check_nginx_system_status.sh"
 SCRIPT_PATH="/usr/local/bin/check_nginx_system_status.sh"
 
 usage() {


### PR DESCRIPTION
## Description

This PR introduces two automation scripts for Nginx monitoring:

1. **`schedule_nginx_systemd_timer.sh`** - Sets up a systemd timer to automate the execution of the `check_nginx_system_status.sh` script every 5 minutes.
2. **`schedule_nginx_health_endpoint_cron.sh`** - Creates a cron job to automate the execution of the `check_nginx_health_endpoint.sh` script every 5 minutes.

These scripts demonstrate the use of both systemd timers and cron jobs for scheduling, providing flexibility in monitoring methods. They are added under the `scripts/sprint2/` directory as part of Sprint 2 deliverables.

## Related Issue

Closes #3

## Changes Introduced

1. Added `schedule_nginx_systemd_timer.sh` to automate scheduling of the system status check script via a systemd timer.
   - Cleans up any existing systemd timer and service for this functionality.
   - Downloads the `check_nginx_system_status.sh` script and sets up the timer/service.
   - Validates the systemd timer setup using `systemctl list-timers`.

2. Added `schedule_nginx_health_endpoint_cron.sh` to automate scheduling of the health endpoint check script via a cron job.
   - Downloads the `check_nginx_health_endpoint.sh` script.
   - Sets up a cron job to execute the script every 5 minutes.
   - Ensures proper permissions and logging for the cron job.

3. Updated relevant documentation in the repository to reflect the addition of these scripts.

## How to Test

1. **Testing `schedule_nginx_systemd_timer.sh`:**
   - Run the script: `sudo ./schedule_nginx_systemd_timer.sh`.
   - Verify the timer setup:
     - Use `systemctl list-timers` to confirm the presence of the timer.
     - Check the logs to ensure the script runs as expected: `journalctl -u nginx_status_check.service`.

2. **Testing `schedule_nginx_health_endpoint_cron.sh`:**
   - Run the script: `sudo ./schedule_nginx_health_endpoint_cron.sh`.
   - Verify the cron job:
     - Use `crontab -l` to confirm the cron job is added.
     - Check the log file specified (`/var/log/nginx_health_cron/health_check.log`) for output from the script execution.

3. Validate that both scripts:
   - Execute their respective monitoring tasks every 5 minutes.
   - Produce the expected output without manual intervention.

## Documentation Updates

- Added a brief usage guide to the README under the `scripts/sprint2/` directory.
- Included script-specific documentation comments for ease of understanding and future maintenance.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have requested a third-party review (e.g., Qodo Merge).
- [x] I have linked this PR to a relevant issue using keywords like "Closes #issue_number".
