### PR TITLE
fix(docs): replace deploy_nginx doc navigation links and translate section

### DIFF
--- a/docs/sprint2/deploy_nginx.md
+++ b/docs/sprint2/deploy_nginx.md
@@ -1,5 +1,5 @@
-[![Read in Portuguese](https://img.shields.io/badge/%F0%9F%87%A7%F0%9F%87%B7%20Portugu%C3%AAs-gray.svg)](README.pt-BR.md)
-[![Read in English](https://img.shields.io/badge/%F0%9F%87%BA%F0%9F%87%B8%20English-F0FFFF.svg)](README.md)
+[![Read in Portuguese](https://img.shields.io/badge/%F0%9F%87%A7%F0%9F%87%B7%20Portugu%C3%AAs-gray.svg)](deploy_nginx.pt-BR.md)
+[![Read in English](https://img.shields.io/badge/%F0%9F%87%BA%F0%9F%87%B8%20English-F0FFFF.svg)](deploy_nginx.md)
 
 ## Overview
 

--- a/docs/sprint2/deploy_nginx.pt-BR.md
+++ b/docs/sprint2/deploy_nginx.pt-BR.md
@@ -1,5 +1,5 @@
-[![Leia em Português](https://img.shields.io/badge/%F0%9F%87%A7%F0%9F%87%B7%20Portugu%C3%AAs-F0FFFF.svg)](README.pt-BR.md)
-[![Leia em Inglês](https://img.shields.io/badge/%F0%9F%87%BA%F0%9F%87%B8%20English-gray.svg)](README.md)
+[![Leia em Português](https://img.shields.io/badge/%F0%9F%87%A7%F0%9F%87%B7%20Portugu%C3%AAs-F0FFFF.svg)](deploy_nginx.pt-BR.md)
+[![Leia em Inglês](https://img.shields.io/badge/%F0%9F%87%BA%F0%9F%87%B8%20English-gray.svg)](deploy_nginx.md)
 
 ## Visão Geral
 

--- a/docs/sprint2/deploy_nginx.pt-BR.md
+++ b/docs/sprint2/deploy_nginx.pt-BR.md
@@ -12,7 +12,7 @@ O script `deploy_nginx.sh` automatiza a instalação e configuração do servido
 - **Gerenciamento de Serviços:** Garante que o Nginx seja habilitado e iniciado para aplicar as configurações.
 - **Flexibilidade:** Suporta os gerenciadores de pacotes `apt` e `dnf` para instalação.
 
-## Script in Action
+## Script em Ação
 
 https://github.com/user-attachments/assets/7e9c4dbb-f49f-44aa-ac87-759b41956ffb
 


### PR DESCRIPTION
## Description

This PR fixes translation navigation links and section without translation at the `deploy_nginx` documentation.

## Related Issue

Patch only, no related issue.

## Changes Introduced

- Translation navigation links at `docs/sprint2/deploy_nginx.md` and `docs/sprint2/deploy_nginx.pt-BR.md`
- `Script in Action` renamed `Script em Ação` at section at `docs/sprint2/deploy_nginx.pt-BR.md`

## Documentation Updates

Only the fixes mentioned above.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have requested a third party review (eg. Qodo Merge)
- [ ] I have linked this PR to a relevant issue using keywords like "Closes #issue_number".
- [ ] I have added tests that prove my changes work (if applicable).
- [x] I have updated documentation (if applicable).