### PR TITLE
fix(doc): add section translation in deploy_nginx.pt-BR.md

### DIFF
--- a/docs/sprint2/deploy_nginx/deploy_nginx.pt-BR.md
+++ b/docs/sprint2/deploy_nginx/deploy_nginx.pt-BR.md
@@ -12,7 +12,7 @@ O script `deploy_nginx.sh` automatiza a instalação e configuração do servido
 - **Gerenciamento de Serviços:** Garante que o Nginx seja habilitado e iniciado para aplicar as configurações.
 - **Flexibilidade:** Suporta os gerenciadores de pacotes `apt` e `dnf` para instalação.
 
-## Script in Action
+## Script em Ação
 
 https://github.com/user-attachments/assets/7e9c4dbb-f49f-44aa-ac87-759b41956ffb
 


### PR DESCRIPTION
## Description

This PR adds a missing section translation to the `deploy_nginx.sh` documentation.

## Related Issue

Patch only, no related issue.

## Changes Introduced

- `docs/sprint2/deploy_nginx/deploy_nginx.pt-BR.md`
  - Translated section `Script in Action` to Brazilian Portuguese -> `Script em Ação`

## Documentation Updates

Only changes mentioned above. 

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have requested a third party review (eg. Qodo Merge)
- [ ] I have linked this PR to a relevant issue using keywords like "Closes #issue_number".
- [ ] I have added tests that prove my changes work (if applicable).
- [x] I have updated documentation (if applicable).