### PR TITLE
fix: add missing `--` to commands in `How to Run` on schedule_nginx_health_endpoint_cron.md

### DIFF
--- a/docs/sprint2/schedule_nginx_health_endpoint_cron/schedule_nginx_health_endpoint_cron.md
+++ b/docs/sprint2/schedule_nginx_health_endpoint_cron/schedule_nginx_health_endpoint_cron.md
@@ -25,14 +25,14 @@ You can quickly download and execute the `schedule_nginx_health_endpoint_cron.sh
 
 ```bash
   wget -qO- https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/main/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh \
-  | sudo bash -s --address http://localhost --user user
+  | sudo bash -s -- --address http://localhost --user user
 ```
 
 #### Using curl:
 
 ```bash
   curl -sL https://raw.githubusercontent.com/georgrybski/compass-devsecops-scholarship/main/scripts/sprint2/schedule_nginx_health_endpoint_cron.sh \
-  | sudo bash -s --address http://localhost --user user
+  | sudo bash -s -- --address http://localhost --user user
 ```
 
 #### Explanation of the Command


### PR DESCRIPTION
## Description

This PR adds missing `--` to commands in `How to Run` on `schedule_nginx_health_endpoint_cron.md`.

Without it, the arguments will not be passed properly.

## Related Issue

Patch only, no related issue.

## Changes Introduced

Added missing `--` to commands in `How to Run` on `schedule_nginx_health_endpoint_cron.md`.

## How to Test

<!-- Provide step-by-step instructions to verify the changes. Include setup and testing scenarios. -->

## Documentation Updates

Only the mentioned above.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have requested a third party review (eg. Qodo Merge)
- [ ] I have linked this PR to a relevant issue using keywords like "Closes #issue_number".
- [ ] I have added tests that prove my changes work (if applicable).
- [x] I have updated documentation (if applicable).